### PR TITLE
feat(setup): Add setup script for Debian-based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,59 +95,89 @@ Adjust the dependencies accordingly based on your custom configuration.
 
 ## Installation
 
-### 1. Clone the Repository 
+### Manual Installation
 
-Clone the fss repository from GitHub. You can do this using either
-HTTPS or SSH. Choose the method that suits your setup:
+1. Clone the Repository 
 
-- *Using HTTPS:* 
-  ```bash 
-  git clone https://github.com/5n00py/fss.git
+  Clone the fss repository from GitHub. You can do this using either
+  HTTPS or SSH. Choose the method that suits your setup:
+
+  - *Using HTTPS:* 
+    ```bash 
+    git clone https://github.com/5n00py/fss.git
+    ```
+
+  - *Using SSH:* 
+    ```bash 
+    git clone git@github.com:5n00py/fss.git
+    ```
+
+2. Make the Scripts Executable 
+
+  Ensure the scripts in the tools directory are executable.
+
+  ```bash
+  chmod +x /path/to/fss/tools/*
   ```
 
-- *Using SSH:* 
-  ```bash 
-  git clone git@github.com:5n00py/fss.git
+  Don't forget to replace `/path/to/fss` with the actual path.
+
+3. Add the Scripts to Your PATH 
+
+  Set the `FSS_ROOT_DIR` environment variable to the path of the cloned `fss`
+  repository. This allows the scripts to correctle source configurations and
+  libraries.
+  ```bash
+  export FSS_ROOT_DIR="$HOME/path/to/fss"
   ```
 
-### 2. Make the Scripts Executable 
+  Include the `fss` tools directory in your `PATH` for convenient access to the
+  scripts:
 
-Ensure the scripts in the tools directory are executable.
+  ```bash
+  export PATH="$FSS_ROOT_DIR/tools:$PATH"
+  ```
 
-```bash
-chmod +x /path/to/fss/tools/*
-```
+  *Note:* Don't forget to replace `/path/to/fss` with the actual path to the
+  `fss` project.
 
-Don't forget to replace `/path/to/fss` with the actual path.
+  To make these changes permanent, append the above export commands to your 
+  shell's configuration file (such as `~/.bashrc` for Bash or `~/.zshrc` for Zsh).
 
-### 3. Add the Scripts to Your PATH 
+  Apply the changes by reloading your shell configuration:
 
-Set the `FSS_ROOT_DIR` environment variable to the path of the cloned `fss`
-repository. This allows the scripts to correctle source configurations and
-libraries.
-```bash
-export FSS_ROOT_DIR="$HOME/path/to/fss"
-```
+  ```bash
+  source ~/.bashrc    # For Bash
+  source ~/.zshrc     # For Zsh
+  ```
 
-Include the `fss` tools directory in your `PATH` for convenient access to the
-scripts:
+### Using the Setup Script
 
-```bash
-export PATH="$FSS_ROOT_DIR/tools:$PATH"
-```
+For a quicker setup on Debian-based systems, you can use an automated [setup
+script](/setup/setup_deb.sh) to install all necessary dependencies, making the
+scripts executable, copying the default configuration file and updating the
+shell configuration automatically.
 
-*Note:* Don't forget to replace `/path/to/fss` with the actual path to the
-`fss` project.
+**Warning:**
+- The setup script will create a symbolic link for `fd` if it's installed as
+  `fdfind` due to naming conflicts in some Debian-based distributions.
+- The script will automatically modify your `.bashrc` and `.zshrc` files, if they
+  exist, to update the PATH and set environment variables.
 
-To make these changes permanent, append the above export commands to your 
-shell's configuration file (such as `~/.bashrc` for Bash or `~/.zshrc` for Zsh).
+1. Clone the repository as described in the "Manual Installation" above.
 
-Apply the changes by reloading your shell configuration:
+2. Navigate to the setup directory, make the script executable and run it:
 
-```bash
-source ~/.bashrc    # For Bash
-source ~/.zshrc     # For Zsh
-```
+  ```bash
+  cd fss/setup && chmod +x setup_deb.sh && ./setup_deb.sh
+  ```
+
+3. Reload your shell configuration:
+
+  ```bash
+  source ~/.bashrc    # For Bash
+  source ~/.zshrc     # For Zsh
+  ```
 
 ## Configuration
 

--- a/setup/setup_deb.sh
+++ b/setup/setup_deb.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Setup script for installing FunkyShellSearch (fss) dependencies and
+# configuration
+
+# Navigate to the root directory of the fss project
+cd "$(dirname "$0")"/../ || exit
+FSS_ROOT_DIR="$(pwd)"
+
+echo "FSS root directory: $FSS_ROOT_DIR"
+
+# Update package lists
+echo "Updating package lists..."
+sudo apt-get update
+
+# Install The Silver Searcher (ag)
+echo "Installing The Silver Searcher (ag)..."
+sudo apt-get install -y silversearcher-ag
+
+# Install fd (fd-find on Debian)
+echo "Installing fd (as fd-find)..."
+sudo apt-get install -y fd-find
+
+# Creating a symbolic link for fd if it's named fdfind
+if command -v fdfind &>/dev/null; then
+    echo "Creating a symbolic link for 'fd'..."
+	sudo ln -snf "$(which fdfind)" /usr/local/bin/fd
+fi
+
+# Install fzf
+echo "Installing fzf..."
+sudo apt-get install -y fzf
+
+# Install grep (usually pre-installed)
+echo "Ensuring grep is installed..."
+sudo apt-get install -y grep
+
+# Install pdfgrep
+echo "Installing pdfgrep..."
+sudo apt-get install -y pdfgrep
+
+# Install additional utilities
+echo "Installing additional utilities..."
+
+# Install chafa
+sudo apt-get install -y chafa
+
+# Install feh
+sudo apt-get install -y feh
+
+# Install mediainfo
+sudo apt-get install -y mediainfo
+
+# Install mpv
+sudo apt-get install -y mpv
+
+# Install Neovim
+sudo apt-get install -y neovim
+
+# Install pdftotext (part of poppler-utils)
+sudo apt-get install -y poppler-utils
+
+# Install zathura
+sudo apt-get install -y zathura
+
+echo "Installation of dependencies completed."
+
+# Make the scripts in the tools directory executable
+echo "Making scripts executable..."
+chmod +x "$FSS_ROOT_DIR"/tools/*
+
+# Function to update shell configuration file
+update_shell_config() {
+    local shell_config="$1"
+    echo "Updating $shell_config..."
+
+    # Check if FSS_ROOT_DIR is already set in the configuration
+    if ! grep -q "FSS_ROOT_DIR" "$shell_config"; then
+        echo "export FSS_ROOT_DIR=\"$FSS_ROOT_DIR\"" >> "$shell_config"
+        echo "export PATH=\"$FSS_ROOT_DIR/tools:\$PATH\"" >> "$shell_config"
+    else
+        echo "FSS_ROOT_DIR already set in $shell_config"
+    fi
+}
+
+# Update .bashrc and .zshrc if they exist
+[ -f "$HOME/.bashrc" ] && update_shell_config "$HOME/.bashrc"
+[ -f "$HOME/.zshrc" ] && update_shell_config "$HOME/.zshrc"
+
+# Copy the default configuration file to the user's .config/fss directory
+echo "Copying the default configuration file to your .config/fss directory..."
+mkdir -p "$HOME/.config/fss"
+cp "$FSS_ROOT_DIR/config/fss.conf" "$HOME/.config/fss/fss.conf"
+
+echo "Configuration file copied. You can modify it according to your needs at ~/.config/fss/fss.conf"
+
+echo "FunkyShellSearch (fss) setup completed successfully!"


### PR DESCRIPTION
- Added a new setup script called `setup_deb.sh`
- The setup script installs all necessary dependencies and configurations
- The script updates the `.bashrc` and `.zshrc` files to update the PATH and set environment variables
- The script also copies the default configuration file to the user's `.config/fss` directory
- The setup instructions in the README.md have been updated to include the usage of the new setup script